### PR TITLE
fix: 当服务列表为空时进行友好提示(#14)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -178,6 +178,10 @@ func Status(services ...string) {
 		}
 	}
 	wg.Wait()
+	if len(views) < 1 {
+		fmt.Printf("请检查工作目录[%s]或执行`skrctl add`将服务进行纳管\n", C.workDir)
+		os.Exit(0)
+	}
 	sort.SliceStable(views, func(i, j int) bool {
 		return views[i].Name < views[j].Name
 	})


### PR DESCRIPTION
执行skrctl ps服务列表为空可能的原因:
- 进错目录了，当前目录可能不是上次的工作目录
- 从来没有使用过skrctl
add命令将服务托管

Closes #14